### PR TITLE
UIのトーンと見た目の統一を調整

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -275,7 +275,7 @@ export default function DashboardPage() {
           <div className="flex items-center gap-2">
             <button
               onClick={openAdd}
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-full btn btn-primary px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
               disabled={status !== "ok"}
               type="button"
             >
@@ -283,9 +283,9 @@ export default function DashboardPage() {
             </button>
             <Link
               href="/matches"
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
             >
-              試合一覧へ
+              試合ログへ
             </Link>
           </div>
         }
@@ -426,21 +426,21 @@ export default function DashboardPage() {
                     <button
                       type="button"
                       onClick={() => setRating(task.id, "○")}
-                      className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                      className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                     >
                       ○
                     </button>
                     <button
                       type="button"
                       onClick={() => setRating(task.id, "△")}
-                      className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                      className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                     >
                       △
                     </button>
                     <button
                       type="button"
                       onClick={() => setRating(task.id, "×")}
-                      className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                      className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                     >
                       ×
                     </button>
@@ -463,7 +463,7 @@ export default function DashboardPage() {
             href="/matches"
             className="text-sm font-semibold underline-offset-4 hover:underline"
           >
-            一覧を見る
+            試合ログを見る
           </Link>
         </div>
 
@@ -529,12 +529,12 @@ export default function DashboardPage() {
                 <div>
                   <h3 className="text-lg font-semibold">試合を追加</h3>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    試合情報と課題評価（○△×）をまとめて保存します
+                    試合情報と課題評価（○△×）をまとめて記録します
                   </p>
                 </div>
                 <button
                   onClick={closeAdd}
-                  className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                  className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                   type="button"
                 >
                   閉じる
@@ -561,7 +561,7 @@ export default function DashboardPage() {
                       type="button"
                       onClick={() => setForm((p) => ({ ...p, is_win: "win" }))}
                       className={`flex-1 rounded-full border px-4 py-2 text-sm font-semibold transition hover:shadow-sm ${
-                        form.is_win === "win" ? "bg-emerald-50" : "bg-white"
+                        form.is_win === "win" ? "badge-ink" : "btn"
                       }`}
                     >
                       WIN
@@ -570,7 +570,7 @@ export default function DashboardPage() {
                       type="button"
                       onClick={() => setForm((p) => ({ ...p, is_win: "lose" }))}
                       className={`flex-1 rounded-full border px-4 py-2 text-sm font-semibold transition hover:shadow-sm ${
-                        form.is_win === "lose" ? "bg-rose-50" : "bg-white"
+                        form.is_win === "lose" ? "badge-salmon" : "btn"
                       }`}
                     >
                       LOSE
@@ -652,21 +652,21 @@ export default function DashboardPage() {
                             <button
                               type="button"
                               onClick={() => setRating(task.id, "○")}
-                              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                             >
                               ○
                             </button>
                             <button
                               type="button"
                               onClick={() => setRating(task.id, "△")}
-                              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                             >
                               △
                             </button>
                             <button
                               type="button"
                               onClick={() => setRating(task.id, "×")}
-                              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                             >
                               ×
                             </button>
@@ -682,17 +682,17 @@ export default function DashboardPage() {
                   <button
                     type="button"
                     onClick={closeAdd}
-                    className="flex-1 inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                    className="flex-1 inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
                     disabled={isSubmitting}
                   >
                     キャンセル
                   </button>
                   <button
                     type="submit"
-                    className="flex-1 inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
+                    className="flex-1 inline-flex items-center justify-center rounded-full btn btn-primary px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
                     disabled={isSubmitting}
                   >
-                    {isSubmitting ? "保存中..." : "保存"}
+                    {isSubmitting ? "試合を記録中..." : "試合を記録"}
                   </button>
                 </div>
               </form>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3,6 +3,19 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+
+  /* Palette */
+  --ink: #0b3d91; /* インクブルー（メイン） */
+  --ink-foreground: #ffffff;
+  --ink-100: #e9eefb;
+
+  --salmon: #ff6b6b; /* サーモンピンク（アクセント） */
+  --salmon-foreground: #ffffff;
+  --salmon-100: #fff0f0;
+
+  --muted-foreground: #64748b; /* グレー系テキスト */
+  --border: #e6e9ee;
+  --motion-duration: 180ms;
 }
 
 @theme inline {
@@ -23,4 +36,113 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* Buttons / Badges / Emphasis - keep color usage to these elements */
+.btn {
+  display: inline-flex;
+  height: 2.5rem; /* h-10 */
+  align-items: center;
+  justify-content: center;
+  padding: 0 1rem;
+  border-radius: 9999px;
+  background: #ffffff;
+  color: var(--foreground);
+  border: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 0.875rem;
+  transition: transform var(--motion-duration) ease, box-shadow var(--motion-duration) ease, filter var(--motion-duration) ease;
+}
+
+.btn-primary {
+  background: var(--ink);
+  color: var(--ink-foreground);
+  border: 1px solid transparent;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(16, 24, 40, 0.06);
+}
+
+.btn-primary:hover {
+  filter: brightness(0.95);
+}
+
+.badge-ink {
+  background: var(--ink-100);
+  color: var(--ink);
+}
+
+.badge-salmon {
+  background: var(--salmon-100);
+  color: var(--salmon);
+}
+
+.rating-yes {
+  background: var(--ink-100);
+  color: var(--ink);
+}
+.rating-no {
+  background: var(--salmon-100);
+  color: var(--salmon);
+}
+.rating-neutral {
+  background: #f8fafc;
+  color: var(--muted-foreground);
+}
+.rating-empty {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.text-muted-foreground {
+  color: var(--muted-foreground) !important;
+}
+
+.text-accent {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+/* Card base to keep cards neutral and consistent */
+.card {
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background: var(--background);
+}
+
+/* Card hover subtle lift */
+.card {
+  transition: box-shadow var(--motion-duration) ease, transform var(--motion-duration) ease;
+}
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(16, 24, 40, 0.06);
+}
+
+/* Common circular badge for ratings */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 1.75rem; /* h-7 */
+  width: 1.75rem; /* w-7 */
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  transition: box-shadow var(--motion-duration) ease, transform var(--motion-duration) ease, background-color var(--motion-duration) ease;
+}
+
+/* Result badges (pill) */
+.result-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  transition: background-color var(--motion-duration) ease, transform var(--motion-duration) ease;
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -47,10 +47,10 @@ export default function LoginPage() {
       <PageHeader
         title="ログイン"
         description="登録済みのメールアドレスとパスワードを入力してね。"
-        right={
+          right={
           <Link
             href="/dashboard"
-            className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+            className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
           >
             ホームへ
           </Link>
@@ -100,7 +100,7 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={loading}
-              className="inline-flex h-10 w-full items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
+              className="inline-flex w-full items-center justify-center rounded-full btn btn-primary px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
             >
               {loading ? "ログイン中..." : "ログイン"}
             </button>

--- a/frontend/src/app/matches/[id]/page.tsx
+++ b/frontend/src/app/matches/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function MatchDetailPage() {
 
       setIsEditingNote(false);
     } catch (e) {
-      alert("保存に失敗しました");
+      alert("試合の記録に失敗しました");
     } finally {
       setSavingNote(false);
     }
@@ -110,7 +110,7 @@ export default function MatchDetailPage() {
   if (status === "loading") {
     return (
       <div className="space-y-4">
-        <PageHeader title="試合詳細" right={<Link href="/matches" className="underline-offset-4 hover:underline text-sm font-semibold">一覧へ</Link>} />
+        <PageHeader title="この試合の振り返り" right={<Link href="/matches" className="underline-offset-4 hover:underline text-sm font-semibold">試合ログへ</Link>} />
         <Card className="p-6">
           <p className="text-sm text-muted-foreground">読み込み中...</p>
         </Card>
@@ -121,12 +121,12 @@ export default function MatchDetailPage() {
   if (status === "unauth") {
     return (
       <div className="space-y-4">
-        <PageHeader title="試合詳細" description="ログインが必要です" />
+        <PageHeader title="この試合の振り返り" description="ログインが必要です" />
         <Card className="p-6">
           <p className="text-sm text-muted-foreground">ログインしてね。</p>
           <div className="mt-4">
             <Link
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+              className="inline-flex items-center justify-center rounded-full btn btn-primary px-4 text-sm font-semibold transition hover:shadow-sm"
               href="/login"
             >
               /loginへ
@@ -140,17 +140,17 @@ export default function MatchDetailPage() {
   if (status === "error" || !data) {
     return (
       <div className="space-y-4">
-        <PageHeader title="試合詳細" description="読み込みに失敗しました" />
+        <PageHeader title="この試合の振り返り" description="読み込みに失敗しました" />
         <Card className="p-6">
           <p className="text-sm text-muted-foreground">
             データの取得に失敗したかも。
           </p>
           <div className="mt-4">
             <Link
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
               href="/matches"
             >
-              一覧へ戻る
+              試合ログへ戻る
             </Link>
           </div>
         </Card>
@@ -162,15 +162,15 @@ export default function MatchDetailPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader
-        title="試合詳細"
+        <PageHeader
+        title="この試合の振り返り"
         description={match.played_at ? `日時：${playedAtText}` : undefined}
         right={
           <Link
             href="/matches"
-            className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+            className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
           >
-            一覧へ
+            試合ログへ
           </Link>
         }
       />
@@ -242,19 +242,19 @@ export default function MatchDetailPage() {
 
             <div className="flex gap-2">
               <button
-                className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
+                className="inline-flex items-center justify-center rounded-full btn btn-primary px-4 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
                 onClick={saveNote}
                 disabled={savingNote}
                 type="button"
               >
-                {savingNote ? "保存中..." : "保存"}
+                {savingNote ? "試合を記録中..." : "試合を記録"}
               </button>
 
               <Link
                 href="/matches"
-                className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+                className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
               >
-                一覧へ
+                試合ログへ
               </Link>
             </div>
           </div>

--- a/frontend/src/app/matches/new/page.tsx
+++ b/frontend/src/app/matches/new/page.tsx
@@ -122,7 +122,7 @@ export default function NewMatchPage() {
       };
 
       await api.post("/api/matches-with-ratings", payload);
-      setMessage("保存しました ✅");
+      setMessage("試合を記録しました ✅");
       resetForm();
     } catch (e: any) {
       console.error(e);
@@ -131,7 +131,7 @@ export default function NewMatchPage() {
         setErrors(apiErrors ?? {});
         setMessage("入力内容を確認してください");
       } else {
-        setMessage("保存に失敗しました");
+        setMessage("試合の記録に失敗しました");
       }
     } finally {
       setSaving(false);
@@ -146,18 +146,18 @@ export default function NewMatchPage() {
     <div className="space-y-6">
       <PageHeader
         title="試合追加"
-        description="試合情報と課題評価（○△×）をまとめて保存します"
+        description="試合情報と課題評価（○△×）をまとめて記録します"
         right={
           <div className="flex items-center gap-2">
             <Link
               href="/matches"
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
             >
-              一覧へ
+              試合ログへ
             </Link>
             <Link
               href="/dashboard"
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
             >
               ホームへ
             </Link>
@@ -359,25 +359,25 @@ export default function NewMatchPage() {
             type="button"
             onClick={onSubmit}
             disabled={saving || loadingTasks}
-            className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-6 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-full btn btn-primary px-6 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
           >
-            {saving ? "保存中..." : "保存"}
+            {saving ? "試合を記録中..." : "試合を記録"}
           </button>
 
           <button
             type="button"
             onClick={resetForm}
             disabled={saving}
-            className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-6 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-full btn px-6 text-sm font-semibold transition hover:shadow-sm disabled:opacity-50"
           >
             リセット
           </button>
 
           <Link
             href="/matches"
-            className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-6 text-sm font-semibold transition hover:shadow-sm"
+            className="inline-flex items-center justify-center rounded-full btn px-6 text-sm font-semibold transition hover:shadow-sm"
           >
-            一覧へ戻る
+            試合ログへ戻る
           </Link>
         </div>
 
@@ -393,9 +393,9 @@ export default function NewMatchPage() {
             console.log("matches:", res.data);
             alert("consoleに出したよ！");
           }}
-          className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-6 text-sm font-semibold transition hover:shadow-sm"
+          className="inline-flex items-center justify-center rounded-full btn px-6 text-sm font-semibold transition hover:shadow-sm"
         >
-          （デバッグ）試合一覧を取得してconsole表示
+          （デバッグ）試合ログを取得してconsole表示
         </button>
       </Card>
     </div>

--- a/frontend/src/app/matches/page.tsx
+++ b/frontend/src/app/matches/page.tsx
@@ -73,16 +73,16 @@ export default function MatchesPage() {
   if (status === "unauth") {
     return (
       <div className="space-y-4">
-        <PageHeader title="試合一覧" description="ログインが必要です" />
+        <PageHeader title="試合ログ" description="ログインが必要です" />
         <Card className="p-6">
           <p className="text-sm text-muted-foreground">ログインしてね。</p>
           <div className="mt-4">
             <Link
-              href="/login"
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
-            >
-              /loginへ
-            </Link>
+                href="/login"
+                className="inline-flex items-center justify-center rounded-full btn btn-primary px-4 text-sm font-semibold transition hover:shadow-sm"
+              >
+                /loginへ
+              </Link>
           </div>
         </Card>
       </div>
@@ -93,19 +93,19 @@ export default function MatchesPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title={`試合一覧（${date}）`}
+        title={`試合ログ（${date}）`}
         description="日付を切り替えて試合を確認できます"
         right={
           <div className="flex items-center gap-2">
-            <Link
+                <Link
               href="/dashboard"
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+              className="inline-flex items-center justify-center rounded-full btn px-4 text-sm font-semibold transition hover:shadow-sm"
             >
               ホームへ
             </Link>
             <Link
               href="/matches/new"
-              className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+              className="inline-flex items-center justify-center rounded-full btn btn-primary px-4 text-sm font-semibold transition hover:shadow-sm"
             >
               ＋ 試合追加
             </Link>
@@ -118,13 +118,13 @@ export default function MatchesPage() {
         <div className="flex flex-wrap items-center gap-2">
           <button
             onClick={setToday}
-            className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+            className="btn px-4 text-sm font-semibold transition hover:shadow-sm"
           >
             今日
           </button>
           <button
             onClick={setYesterday}
-            className="inline-flex h-10 items-center justify-center rounded-full border bg-white px-4 text-sm font-semibold transition hover:shadow-sm"
+            className="btn px-4 text-sm font-semibold transition hover:shadow-sm"
           >
             昨日
           </button>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -122,7 +122,7 @@ export default function RegisterPage() {
           <button
             type="submit"
             disabled={isSubmitting}
-            className="w-full inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium bg-emerald-500 hover:bg-emerald-400 disabled:opacity-60 disabled:cursor-not-allowed transition mt-4"
+            className="w-full inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium btn btn-primary disabled:opacity-60 disabled:cursor-not-allowed transition mt-4"
           >
             {isSubmitting ? "登録中..." : "アカウントを作成する"}
           </button>
@@ -132,7 +132,7 @@ export default function RegisterPage() {
           すでにアカウントをお持ちの方は{" "}
           <a
             href="/login"
-            className="text-emerald-400 hover:underline"
+            className="text-accent hover:underline"
           >
             ログイン
           </a>

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -111,7 +111,7 @@ export default function TasksPage() {
             <button
               type="submit"
               disabled={submitting}
-              className="px-4 py-2 rounded-lg bg-emerald-500/80 hover:bg-emerald-400 disabled:opacity-50 text-sm font-medium"
+              className="px-4 py-2 rounded-lg btn btn-primary disabled:opacity-50 text-sm font-medium"
             >
               {submitting ? "追加中..." : "追加"}
             </button>

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -9,7 +9,7 @@ export function Card({ children, className, ...props }: Props) {
   return (
     <div
       className={cn(
-        "rounded-2xl border bg-white p-4 shadow-sm",
+        "card p-4 shadow-sm",
         "transition hover:shadow-md hover:-translate-y-px",
         className
       )}

--- a/frontend/src/components/ui/RatingBadge.tsx
+++ b/frontend/src/components/ui/RatingBadge.tsx
@@ -3,10 +3,10 @@ import { cn } from "@/lib/utils";
 type Rating = "○" | "△" | "×" | "-";
 
 const styles: Record<Rating, string> = {
-  "○": "bg-emerald-100 text-emerald-700",
-  "△": "bg-amber-100 text-amber-700",
-  "×": "bg-rose-100 text-rose-700",
-  "-": "bg-slate-100 text-slate-600",
+  "○": "rating-yes",
+  "△": "rating-neutral",
+  "×": "rating-no",
+  "-": "rating-empty",
 };
 
 export function RatingBadge({
@@ -19,7 +19,7 @@ export function RatingBadge({
   return (
     <span
       className={cn(
-        "inline-flex h-7 w-7 items-center justify-center rounded-full text-sm font-bold",
+        "badge",
         styles[rating],
         className
       )}

--- a/frontend/src/components/ui/ResultBadge.tsx
+++ b/frontend/src/components/ui/ResultBadge.tsx
@@ -8,15 +8,13 @@ type Props = {
 export function ResultBadge({ isWin, className }: Props) {
   if (isWin === null) return null;
 
-  const label = isWin ? "WIN" : "LOSE";
+  const label = isWin ? "勝ち" : "負け";
 
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
-        isWin
-          ? "bg-emerald-100 text-emerald-700"
-          : "bg-rose-100 text-rose-700",
+        "result-badge",
+        isWin ? "badge-ink" : "badge-salmon",
         className
       )}
     >


### PR DESCRIPTION
① 色を1〜2色に絞る

メイン：インクブルー

アクセント：サーモンピンク

やること

ボタン / バッジ / 強調テキストだけ色つける

それ以外は 白＋グレー系 に逃がす

② ○△×の“見た目ルール”最終調整

丸バッジ統一

色ルール固定

○：ブルー寄り

△：グレー or 薄ピンク

×：サーモンピンク

サイズ・影を統一

③ hover / transition を最低限だけ

ボタン

hoverでちょい暗くなる or 浮く

カード

hoverで影が少し強くなる

アニメーションは0.15〜0.2s くらい

④ 文言を“プロダクトっぽく”そろえる

「保存」→「試合を記録」

「一覧」→「試合ログ」

「詳細」→「この試合の振り返り」